### PR TITLE
change 'arsenal' to 'arsenal tula' for 2014/2015 season

### DIFF
--- a/2014-15/rfpl-i.txt
+++ b/2014-15/rfpl-i.txt
@@ -95,7 +95,7 @@ Matchday 6
 Matchday 7
 
 [Sat. 13.09.]
-  CSKA                2-1  Arsenal
+  CSKA                2-1  Arsenal Tula
   Zenit               3-2  Dinamo
   Rostov              1-2  Rubin
   Lokomotiv           1-1  Mordovia
@@ -110,7 +110,7 @@ Matchday 7
 Matchday 8
 
 [Fri. 19.09.]
-  Arsenal             0-1  Mordovia
+  Arsenal Tula        0-1  Mordovia
 [Sat. 20.09.]
   Ufa                 0-1  Ural
   Rostov              0-5  Zenit
@@ -132,7 +132,7 @@ Matchday 9
 [Sun. 28.09.]
   Dinamo              2-2  Kuban
   Lokomotiv           3-1  Amkar
-  Krasnodar           3-0  Arsenal
+  Krasnodar           3-0  Arsenal Tula
   Terek               2-1  Rostov
 [Mon. 29.09.]
   Rubin               2-1  Torpedo
@@ -146,7 +146,7 @@ Matchday 10
   Lokomotiv           2-1  Terek
 [Sun. 19.10.]
   Ural                2-0  Spartak
-  Arsenal             1-1  Rostov
+  Arsenal Tula        1-1  Rostov
 [Mon. 20.10.]
   Ufa                 1-1  Torpedo
   Rubin               5-0  Mordovia
@@ -157,7 +157,7 @@ Matchday 10
 Matchday 11
 
 [Fri. 24.10.]
-  Ural                1-0  Arsenal
+  Ural                1-0  Arsenal Tula
 [Sat. 25.10.]
   Amkar               2-0  Rostov
   Torpedo             0-0  Kuban
@@ -181,7 +181,7 @@ Matchday 12
   Mordovia            2-1  Krasnodar
   Kuban               3-3  Spartak
 [Mon. 03.11.]
-  Torpedo             0-1  Arsenal
+  Torpedo             0-1  Arsenal Tula
   Rubin               1-1  Amkar
   Terek               1-0  Ufa
 
@@ -198,7 +198,7 @@ Matchday 13
   Dinamo              1-0  CSKA
   Ufa                 0-0  Rostov
   Krasnodar           2-0  Rubin
-  Spartak             2-0  Arsenal
+  Spartak             2-0  Arsenal Tula
 
 
 Matchday 14
@@ -210,7 +210,7 @@ Matchday 14
   Zenit               1-0  Kuban
 [Sun. 23.11.]
   Dinamo              3-0  Terek
-  Arsenal             4-0  Amkar
+  Arsenal Tula        4-0  Amkar
   Spartak             4-2  Mordovia
 [Mon. 24.11.]
   Lokomotiv           0-0  Ufa
@@ -221,7 +221,7 @@ Matchday 15
 [Fri. 28.11.]
   Rostov              1-1  Amkar
 [Sat. 29.11.]
-  Arsenal             1-2  Ural
+  Arsenal Tula        1-2  Ural
   CSKA                5-0  Ufa
   Mordovia            1-0  Zenit
   Kuban               1-1  Torpedo

--- a/2014-15/rfpl-i.txt
+++ b/2014-15/rfpl-i.txt
@@ -6,7 +6,7 @@ Matchday 1
   Rubin               0-4  Spartak
 [Sat. 02.08.]
   Ural                2-3  Mordovia
-  Arsenal             0-4  Zenit
+  Arsenal Tula        0-4  Zenit
   CSKA                4-1  Torpedo
 [Sun. 03.08.]
   Dinamo              7-3  Rostov
@@ -28,7 +28,7 @@ Matchday 2
 [Sun. 10.08.]
   Dinamo              1-2  Spartak
   Ural                1-1  Krasnodar
-  Arsenal             0-2  Lokomotiv
+  Arsenal Tula        0-2  Lokomotiv
 
 
 Matchday 3
@@ -38,7 +38,7 @@ Matchday 3
 [Wed. 13.08.]
   Ufa                 0-2  Dinamo
   Ural                1-2  Zenit
-  Arsenal             0-0  Rubin
+  Arsenal Tula        0-0  Rubin
   CSKA                1-0  Terek
 [Thu. 14.08.]
   Lokomotiv           2-1  Rostov
@@ -54,7 +54,7 @@ Matchday 4
   Zenit               1-0  Ufa
 [Sun. 17.08.]
   CSKA                0-1  Spartak
-  Arsenal             1-2  Dinamo
+  Arsenal Tula        1-2  Dinamo
   Rubin               1-1  Lokomotiv
   Rostov              0-2  Krasnodar
 [Mon. 18.08.]
@@ -65,7 +65,7 @@ Matchday 4
 Matchday 5
 
 [Fri. 22.08.]
-  Terek               3-0  Arsenal
+  Terek               3-0  Arsenal Tula
 [Sat. 23.08.]
   Ufa                 1-2  Spartak
   Zenit               2-0  Amkar
@@ -84,7 +84,7 @@ Matchday 6
 [Sat. 30.08.]
   Mordovia            1-0  Torpedo
   Amkar               2-0  Spartak
-  Arsenal             0-1  Kuban
+  Arsenal Tula        0-1  Kuban
 [Sun. 31.08.]
   CSKA                6-0  Rostov
   Rubin               1-1  Ufa

--- a/2014-15/rfpl-ii.txt
+++ b/2014-15/rfpl-ii.txt
@@ -4,7 +4,7 @@ Matchday 16
 
 [Tue. 02.12.]
   CSKA                2-1  Amkar
-  Arsenal             0-1  Ufa
+  Arsenal Tula        0-1  Ufa
 [Wed. 03.12.]
   Rubin               0-1  Zenit
   Lokomotiv           1-0  Ural
@@ -26,7 +26,7 @@ Matchday 17
 [Mon. 08.12.]
   Torpedo             2-2  Ufa
   Mordovia            0-1  Rubin
-  Rostov              0-1  Arsenal
+  Rostov              0-1  Arsenal Tula
   Spartak             2-0  Ural
 
 
@@ -41,7 +41,7 @@ Matchday 18
   Rostov              0-1  Lokomotiv
 [Mon. 09.03.]
   Amkar               0-0  Torpedo
-  Rubin               1-0  Arsenal
+  Rubin               1-0  Arsenal Tula
   Kuban               0-0  Mordovia
 
 
@@ -52,7 +52,7 @@ Matchday 19
 [Sat. 14.03.]
   Ufa                 1-1  Amkar
   CSKA                4-0  Mordovia
-  Lokomotiv           0-1  Arsenal
+  Lokomotiv           0-1  Arsenal Tula
 [Sun. 15.03.]
   Spartak             1-0  Dinamo
   Torpedo             1-1  Zenit
@@ -67,7 +67,7 @@ Matchday 20
   Ufa                 0-2  Krasnodar
 [Sat. 21.03.]
   Ural                1-0  Amkar
-  Arsenal             1-4  CSKA
+  Arsenal Tula        1-4  CSKA
   Rubin               2-0  Rostov
   Torpedo             0-1  Spartak
 [Sun. 22.03.]
@@ -87,7 +87,7 @@ Matchday 21
   Zenit               2-1  CSKA
   Ural                0-1  Rostov
   Ufa                 0-1  Terek
-  Arsenal             1-3  Torpedo
+  Arsenal Tula        1-3  Torpedo
 
 
 Matchday 22
@@ -101,7 +101,7 @@ Matchday 22
   Lokomotiv           2-0  Torpedo
   CSKA                1-2  Dinamo
 [Thu. 09.04.]
-  Arsenal             1-0  Spartak
+  Arsenal Tula        1-0  Spartak
   Rostov              2-0  Ufa
 
 
@@ -111,7 +111,7 @@ Matchday 23
   Krasnodar           3-2  Kuban
 [Sun. 12.04.]
   Zenit               1-1  Rubin
-  Ufa                 0-1  Arsenal
+  Ufa                 0-1  Arsenal Tula
   Dinamo              2-1  Mordovia
 [Mon. 13.04.]
   Ural                2-0  Lokomotiv
@@ -131,7 +131,7 @@ Matchday 24
   Terek               0-0  Dinamo
   Kuban               0-0  Zenit
 [Mon. 20.04.]
-  Amkar               0-1  Arsenal
+  Amkar               0-1  Arsenal Tula
   Rostov              1-0  Torpedo
 
 
@@ -147,7 +147,7 @@ Matchday 25
 [Sun. 26.04.]
   Spartak             1-0  Rubin
   Rostov              2-2  Dinamo
-  Zenit               1-0  Arsenal
+  Zenit               1-0  Arsenal Tula
 
 
 Matchday 26
@@ -161,7 +161,7 @@ Matchday 26
   Torpedo             2-2  Rubin
 [Mon. 04.05.]
   Ufa                 1-2  Mordovia
-  Arsenal             0-3  Krasnodar
+  Arsenal Tula        0-3  Krasnodar
   CSKA                3-1  Ural
 
 
@@ -176,7 +176,7 @@ Matchday 27
   Zenit               3-0  Rostov
 [Mon. 11.05.]
   Terek               4-2  Spartak
-  Mordovia            1-0  Arsenal
+  Mordovia            1-0  Arsenal Tula
   Krasnodar           1-1  Amkar
 
 
@@ -186,7 +186,7 @@ Matchday 28
   Mordovia            0-0  Rostov
 [Sat. 16.05.]
   Amkar               1-0  Kuban
-  Arsenal             1-1  Terek
+  Arsenal Tula        1-1  Terek
   Lokomotiv           3-0  Rubin
 [Sun. 17.05.]
   Spartak             0-4  CSKA
@@ -205,7 +205,7 @@ Matchday 29
 [Sun. 24.05.]
   Krasnodar           2-1  Rostov
   Mordovia            1-0  Terek
-  Dinamo              2-2  Arsenal
+  Dinamo              2-2  Arsenal Tula
 [Mon. 25.05.]
   Lokomotiv           1-1  Kuban
   CSKA                3-0  Rubin
@@ -215,7 +215,7 @@ Matchday 30
 
 [Sat. 30.05.]
   Dinamo              1-1  Krasnodar
-  Kuban               5-1  Arsenal
+  Kuban               5-1  Arsenal Tula
   Rostov              1-1  CSKA
   Ufa                 1-1  Rubin
   Spartak             3-3  Amkar

--- a/2014-15/rfpl.yml
+++ b/2014-15/rfpl.yml
@@ -14,7 +14,7 @@ fixtures:
 - Dinamo              
 - Krasnodar
 - Kuban               
-- Arsenal
+- Arsenal Tula
 - Rostov              
 - CSKA
 - Ufa                 


### PR DESCRIPTION
@geraldb changed the key and title for Arsenal Tula to 'arsenal tula'  instead of 'arsenal' - I updated the matches and team list for the 2014/2015 season to reflect these changes. I believe that is the only event that Arsenal Tula appears in. 