### PR TITLE
Change Dynamo Moscow key from "dynamo" to "dinamo" in 2015-16

### DIFF
--- a/2015-16/rfpl.yml
+++ b/2015-16/rfpl.yml
@@ -14,7 +14,7 @@ fixtures:
 - Amkar
 - Anzhi
 - CSKA
-- Dynamo
+- Dinamo
 - Krasnodar
 - Krylia Sovetov
 - Kuban


### PR DESCRIPTION
In the rest of the repo, Dynamo Moscow has the key "dinamo" except for in the 2015-16 rfpl.yml file. When I build the database and include major-league-soccer, Houston Dynamo is listed as playing in the Russian Premier League in 2015-16 instead of Dynamo Moscow and I think this may be why.